### PR TITLE
lib: so gay can you use deref

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@ use dashu::{integer::UBig, integer::fast_div::ConstDivisor};
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct BigModExpParams {
-    base: u8,
+    base: *const u8,
     base_len: usize,
-    exponent: u8,
+    exponent: *const u8,
     exponent_len: usize,
-    modulus: u8,
+    modulus: *const u8,
     modulus_len: usize,
 }
 


### PR DESCRIPTION
0.1.1 currently carries some errors from sbf/bpf.

```➜  program git:(feature/web-demo) ✗ cargo build-bpf
   Compiling serde v1.0.215
   Compiling solana-nostd-big-mod-exp v0.1.1
   Compiling serde_derive v1.0.215
error[E0308]: mismatched types
  --> src/lib.rs:31:15
   |
31 |         base: base.as_ptr(),
   |               ^^^^^^^^^^^^^ expected `u8`, found `*const u8`
   |
   = note:     expected type `u8`
           found raw pointer `*const u8`

error[E0308]: mismatched types
  --> src/lib.rs:33:19
   |
33 |         exponent: exponent.as_ptr(),
   |                   ^^^^^^^^^^^^^^^^^ expected `u8`, found `*const u8`
   |
   = note:     expected type `u8`
           found raw pointer `*const u8`

error[E0308]: mismatched types
  --> src/lib.rs:35:18
   |
35 |         modulus: modulus.as_ptr(),
   |                  ^^^^^^^^^^^^^^^^ expected `u8`, found `*const u8`
   |
   = note:     expected type `u8`
           found raw pointer `*const u8`

error[E0308]: mismatched types
  --> src/lib.rs:51:15
   |
51 |         base: base.as_ptr(),
   |               ^^^^^^^^^^^^^ expected `u8`, found `*const u8`
   |
   = note:     expected type `u8`
           found raw pointer `*const u8`

error[E0308]: mismatched types
  --> src/lib.rs:53:19
   |
53 |         exponent: exponent.as_ptr(),
   |                   ^^^^^^^^^^^^^^^^^ expected `u8`, found `*const u8`
   |
   = note:     expected type `u8`
           found raw pointer `*const u8`

error[E0308]: mismatched types
  --> src/lib.rs:55:18
   |
55 |         modulus: modulus.as_ptr(),
   |                  ^^^^^^^^^^^^^^^^ expected `u8`, found `*const u8`
   |
   = note:     expected type `u8`
           found raw pointer `*const u8`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `solana-nostd-big-mod-exp` (lib) due to 6 previous errors
warning: build failed, waiting for other jobs to finish...
➜  program git:(feature/web-demo) ✗ cargo build-spf
error: no such command: `build-spf`

	Did you mean `build-bpf`?

	View all installed commands with `cargo --list`
	Find a package to install `build-spf` with `cargo search cargo-build-spf```